### PR TITLE
extendCodec supports multiple decoders

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -32,7 +32,7 @@ describe("extendCodec", () => {
         (_) => Left("nah"),
         (value) => Right(value * value)
       );
-      expect(extended.decode(5)).toEqual(Right(10000));
+      expect(extended.decode(5)).toEqual(left);
     });
   });
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,38 @@
+import { extendCodec } from "./utils";
+import { number, Left, Right } from "purify-ts";
+
+const left = Left(expect.any(String));
+
+describe("extendCodec", () => {
+  describe("extend codec with decoder(s)", () => {
+    it("should apply chained decoder", () => {
+      const extended = extendCodec(number, (value) => Right(value + 1));
+      expect(extended.decode(5)).toEqual(Right(6));
+    });
+
+    it("should fail with chained decoder", () => {
+      const extended = extendCodec(number, (_) => Left("nope"));
+      expect(extended.decode("foo")).toEqual(left);
+    });
+
+    it("should apply multiple chained decoders", () => {
+      const extended = extendCodec(
+        number,
+        (value) => Right(value + 5),
+        (value) => Right(value * 10),
+        (value) => Right(value * value)
+      );
+      expect(extended.decode(5)).toEqual(Right(10000));
+    });
+
+    it("should fail with multiple chained decoders", () => {
+      const extended = extendCodec(
+        number,
+        (value) => Right(value + 5),
+        (_) => Left("nah"),
+        (value) => Right(value * value)
+      );
+      expect(extended.decode(5)).toEqual(Right(10000));
+    });
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,12 +2,17 @@ import { Codec, Either } from "purify-ts";
 
 export const extendCodec = <T>(
   base: Codec<T>,
-  decoder: (value: T) => Either<string, T>
-): Codec<T> =>
-  Codec.custom<T>({
-    decode: (value) => base.decode(value).chain(decoder),
+  ...decoders: Array<(value: T) => Either<string, T>>
+): Codec<T> => {
+  return Codec.custom<T>({
+    decode: (value) =>
+      (decoders ?? []).reduce(
+        (decoded, decoder) => decoded.chain(decoder),
+        base.decode(value)
+      ),
     encode: base.encode,
   });
+};
 
 export function chainCodec<T1>(c1: Codec<T1>): Codec<T1>;
 export function chainCodec<T1, T2>(c1: Codec<T1>, c2: Codec<T2>): Codec<T2>;


### PR DESCRIPTION
Allow `extendCodec` to accept arbitrarily many decoders